### PR TITLE
Setup package for initial alpha release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 geckodriver.log
 *.pyc
+dist
+build
+*.egg-info

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Perceptual Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## percy-python-selenium
+# percy-python-selenium
 [![CircleCI](https://circleci.com/gh/percy/percy-python-selenium.svg?style=svg)](https://circleci.com/gh/percy/percy-python-selenium)
 
 [Percy](https://percy.io) visual testing for Python Selenium.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,7 @@
+## Releasing
+
+First, this is an excellent resource: https://packaging.python.org/tutorials/packaging-projects/
+
+- Make sure everything is ready to be released to the registry
+- Build the SDK: `yarn build` (this runs a python command)
+- Upload the SDK: `python -m twine upload dist/` (you can find the creds in 1pass)

--- a/package.json
+++ b/package.json
@@ -6,5 +6,9 @@
   "private": true,
   "dependencies": {
     "@percy/agent": "~0"
+  },
+  "scripts": {
+    "prebuild": "rm -rf dist/ build/",
+    "build": "python setup.py sdist bdist_wheel"
   }
 }

--- a/percy/__init__.py
+++ b/percy/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+
+__author__ = 'Perceptual Inc.'
+__email__ = 'team@percy.io'
+__version__ = '0.1.0'
+
+from percy.snapshot import percySnapshot

--- a/percy/snapshot.py
+++ b/percy/snapshot.py
@@ -32,7 +32,7 @@ def postSnapshot(postData):
         if isDebug():
             print(e)
 
-        print('[percy] failed to POST snapshot to percy-agent')
+        print('[percy] failed to POST snapshot to percy-agent:' + postData.get('name'))
         return
 
 def clientInfo():

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,38 @@
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+with open("requirements.txt", "r") as fh:
+    requirements = fh.read()
+
+setuptools.setup(
+    name='percy-python-selenium',
+    version='0.1.0',
+    description='Python client for visual regression testing with Percy (https://percy.io).',
+    author='Perceptual Inc.',
+    author_email='team@percy.io',
+    url='https://github.com/percy/percy-python-selenium',
+    packages=[
+        'percy',
+    ],
+    include_package_data=True,
+    install_requires=requirements,
+    license='MIT',
+    zip_safe=False,
+    keywords='percy',
+    classifiers=[
+        'Development Status :: 2 - Pre-Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+    ],
+    test_suite='tests',
+    tests_require=['selenium']
+)


### PR DESCRIPTION
## What is this?

This PR sets up the new agent based python SDK to be releasable. I tested this on their test package registry: https://test.pypi.org/project/percy-python-selenium/ (which is freakin' awesome btw)

Using that package, you can successfully run this script:

```python
from selenium import webdriver
from percy import percySnapshot

browser = webdriver.Firefox()

browser.get('http://sdk-test.percy.dev')
browser.implicitly_wait(10)
browser.find_element_by_class_name("note")

percySnapshot(browser=browser, name='testing python selenium')
percySnapshot(browser=browser, name='another')

browser.quit()
```