### PR TITLE
chore: Add more Python versions to `classifiers`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,10 @@ setuptools.setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     test_suite='tests',
     tests_require=['selenium']


### PR DESCRIPTION
## What is this?

This adds more Python versions to the `classifiers` field in `setup.py` (up to the current Python). 